### PR TITLE
Butler Initialize

### DIFF
--- a/spec/butler/dispatcher_spec.cr
+++ b/spec/butler/dispatcher_spec.cr
@@ -1,0 +1,9 @@
+require "../spec_helper"
+
+describe Butler::Dispatcher do
+  it "rejects unsupported commands" do
+    expect_raises(Butler::UnknownInstruction) do
+      Butler::Dispatcher.dispatch!(["igbanam"])
+    end
+  end
+end

--- a/spec/butler/instructions_spec.cr
+++ b/spec/butler/instructions_spec.cr
@@ -18,6 +18,23 @@ module Butler
         expectation = File.directory?(".butler")
         expectation.should be_true
       end
+
+      context "when a butler already exists" do
+        it "does not re-initialize project" do
+          no_details = [] of String
+          Initialize.new(no_details).execute
+          fresh = File.size(".butler/service.log")
+          File.open(".butler/service.log", "a") do |file|
+            file.puts "Meaningless test data"
+          end
+          working = File.size(".butler/service.log")
+
+          Initialize.new(no_details).execute
+
+          expected = File.size(".butler/service.log")
+          expected.should_not eq(fresh)
+        end
+      end
     end
 
     Spec.after_each do

--- a/spec/butler/instructions_spec.cr
+++ b/spec/butler/instructions_spec.cr
@@ -1,0 +1,27 @@
+require "file_utils"
+require "../spec_helper"
+
+module Butler
+  module Instruction
+    describe Initialize do
+      it "with details is a malformed instruction" do
+        expect_raises(MalformedInstruction) do
+          Initialize.new(["any"])
+        end
+      end
+
+      it "create a .butler directory" do
+        no_details = [] of String
+
+        Initialize.new(no_details).execute
+
+        expectation = File.directory?(".butler")
+        expectation.should be_true
+      end
+    end
+
+    Spec.after_each do
+      FileUtils.rm_r(".butler") if File.directory?(".butler")
+    end
+  end
+end

--- a/src/butler.cr
+++ b/src/butler.cr
@@ -31,8 +31,9 @@ module Butler
     parser.unknown_args do |input|
       raise UnknownInstruction.new if input.empty?
       Dispatcher.dispatch!(input)
-    rescue e : UnknownInstruction
+    rescue e : UnknownInstruction | MalformedInstruction
       STDERR.puts e.message
+      STDERR.puts e.cause
       STDERR.puts parser
     end
   end

--- a/src/butler.cr
+++ b/src/butler.cr
@@ -1,6 +1,41 @@
-# TODO: Write documentation for `Butler`
+require "option_parser"
+require "./butler/*"
+
+# Keeps track of projects
+#
+# butler init
+#   - initialize a Butler project
+# butler tasks
+#   - show all tasks in the project
+# butler task show ID
+#   - detail the task with ID
+# butler "start-task | task start" ID
+#   - mark a task as started
+# butler "complete-task | tash complete" ID
+#   - mark a task as complete
 module Butler
   VERSION = "0.1.0"
 
-  # TODO: Put your code here
+  OptionParser.parse do |parser|
+    parser.banner = "Usage: butler <command> [<args>]\n\nSupported Commands are:
+    #{Dispatcher::SUPPORTED_INSTRUCTIONS}"
+
+    parser.on "-v", "Show Version" do
+      puts "Butler, version #{VERSION}"
+    end
+
+    parser.on "-h", "Help" do
+      puts parser
+    end
+
+    parser.unknown_args do |input|
+      raise UnknownInstruction.new if input.empty?
+      Dispatcher.dispatch!(input)
+    rescue e : UnknownInstruction
+      STDERR.puts e.message
+      STDERR.puts parser
+    end
+  end
+
+  # Butler::Service.run(command, args)
 end

--- a/src/butler/dispatcher.cr
+++ b/src/butler/dispatcher.cr
@@ -20,8 +20,8 @@ module Butler
     end
 
     private def self.reject!(intent : Array(String))
-      STDERR.puts "I do not understand #{intent}"
-      raise UnknownInstruction.new
+      message = "I do not understand #{intent}"
+      raise UnknownInstruction.new(message: message)
     end
 
     def initialize(@instruction : String, @details : Array(String))

--- a/src/butler/dispatcher.cr
+++ b/src/butler/dispatcher.cr
@@ -1,0 +1,52 @@
+module Butler
+  class Dispatcher
+    SUPPORTED_INSTRUCTIONS = [
+      "init",
+      "tasks"
+    ]
+
+    COMMAND_MAP = {
+      "init" => Butler::Instruction::Initialize,
+    }
+
+    def self.dispatch!(intent : Array(String))
+      return reject! ["[nothing]"] if intent.empty? || intent.first.blank?
+      return reject! intent unless SUPPORTED_INSTRUCTIONS.includes?(intent.first)
+
+      instruction = intent.first
+      details = intent[1..-1]
+
+      new(instruction, details).dispatch
+    end
+
+    private def self.reject!(intent : Array(String))
+      STDERR.puts "I do not understand #{intent}"
+      raise UnknownInstruction.new
+    end
+
+    def initialize(@instruction : String, @details : Array(String))
+    end
+
+    def dispatch : Nil
+      COMMAND_MAP[@instruction].new(@details).execute
+    end
+  end
+
+  # Thoughts around this is one of intent and events. I've been stuck on
+  # thinking about how to represent it for too long, I think it's best I log the
+  # thoughts and move on. The idea is this.
+  #
+  # When a user calls the butler with some input, the input is "registered" as
+  # an intent. This intent then logs an event with the butler service. Then
+  # butler workers can work through the intents, carrying out the specific
+  # tasks to satisfy this intent.
+  #
+  # Here be three classes
+  #   - Intent        what is to be done
+  #   - Event         an occurence in the Butler's mind
+  #   - Task          action performed by a butler to satisfy an intent
+  #
+  # With this logged, it's become a to-do for the future. I will focus on using
+  # the less robust command model to get this done for now, pending when I can
+  # find the zen to think this through.
+end

--- a/src/butler/errors.cr
+++ b/src/butler/errors.cr
@@ -1,0 +1,3 @@
+module Butler
+  class UnknownInstruction < Exception; end
+end

--- a/src/butler/exceptions.cr
+++ b/src/butler/exceptions.cr
@@ -1,0 +1,4 @@
+module Butler
+  class MalformedInstruction < Exception; end
+  class UnknownInstruction < Exception; end
+end

--- a/src/butler/instructions.cr
+++ b/src/butler/instructions.cr
@@ -1,5 +1,8 @@
 module Butler
   BUTLER_DIRECTORY = ".butler"
+  # .butler
+  #   +-> service.log
+  #   +-> tasks.json
 
   module Instruction
     abstract class Instruction
@@ -17,6 +20,13 @@ module Butler
       end
 
       def execute
+        create_butler_directory
+        Butler::Logger.instance.log "Initialized Butler in #{__DIR__}"
+      rescue File::AlreadyExistsError
+        STDERR.puts "Your butler is already initialized."
+      end
+
+      private def create_butler_directory
         Dir.mkdir BUTLER_DIRECTORY
       end
     end

--- a/src/butler/instructions.cr
+++ b/src/butler/instructions.cr
@@ -1,0 +1,21 @@
+module Butler
+  module Instruction
+    abstract class Instruction
+      abstract def execute
+
+      def reject!(reason)
+        raise reason.new
+      end
+    end
+
+    class Initialize < Instruction
+      def initialize(details : Array(String))
+        reject!(reason: MalformedInstruction) unless details.empty?
+      end
+
+      def execute
+        # Initialize the project
+      end
+    end
+  end
+end

--- a/src/butler/instructions.cr
+++ b/src/butler/instructions.cr
@@ -1,20 +1,23 @@
 module Butler
+  BUTLER_DIRECTORY = ".butler"
+
   module Instruction
     abstract class Instruction
       abstract def execute
 
-      def reject!(reason)
-        raise reason.new
+      def reject!(concern)
+        raise concern
       end
     end
 
     class Initialize < Instruction
       def initialize(details : Array(String))
-        reject!(reason: MalformedInstruction) unless details.empty?
+        error_message = "Init syntax is  ---> ./butler init"
+        reject!(concern: MalformedInstruction.new(error_message)) unless details.empty?
       end
 
       def execute
-        # Initialize the project
+        Dir.mkdir BUTLER_DIRECTORY
       end
     end
   end

--- a/src/butler/logger.cr
+++ b/src/butler/logger.cr
@@ -1,0 +1,17 @@
+module Butler
+  class Logger
+    private def initialize
+      @logfile_path = "#{BUTLER_DIRECTORY}/service.log"
+    end
+
+    def self.instance
+      @@instance ||= new
+    end
+
+    def log(message : String) : Nil
+      File.open(@logfile_path, "a") do |log_file|
+        log_file.puts message
+      end
+    end
+  end
+end


### PR DESCRIPTION
To begin a Butler project in a repository, we must initialize the
project to be tracked by a butler. Today, butlers are local to projects
and cannot know anything about their colleagues working on other
projects. This may be a feature extension in the future.

A butler is initialized with all the information it needs to track the
project. There are some assumptions butlers make when working on
projects:

- Butlers assume the project name is the name of the folder
it's being initialized in unless told otherwise.
- Butlers, at this time, only track one project; where the project is in
the folder which runs the `butler init` command.
- Butlers do not care about folder structure today; they may at a later
date

This change is concerned with initializing a butler inside a project.
Details of the decisions made through this change journey can be found
in the commit messages