### PR TITLE
Add the ability to add tasks to the Butler

### DIFF
--- a/spec/butler/dispatcher_spec.cr
+++ b/spec/butler/dispatcher_spec.cr
@@ -1,7 +1,13 @@
+require "file_utils"
 require "../spec_helper"
 
 module Butler
   describe Dispatcher do
+    before_all do
+      FileUtils.rm_rf BUTLER_DIRECTORY
+      Instruction::Initialize.new([] of String).execute
+    end
+
     it "rejects unsupported instructions" do
       expect_raises(UnknownInstruction) do
         Dispatcher.dispatch!(["igbanam"])
@@ -12,6 +18,10 @@ module Butler
       intent = "task add Begin!".split
       instruction = Dispatcher.new(intent.first, intent[1..-1]).route
       instruction.is_a?(Instruction::CreateTask).should be_true
+    end
+
+    after_all do
+      FileUtils.rm_rf BUTLER_DIRECTORY
     end
   end
 end

--- a/spec/butler/dispatcher_spec.cr
+++ b/spec/butler/dispatcher_spec.cr
@@ -1,9 +1,17 @@
 require "../spec_helper"
 
-describe Butler::Dispatcher do
-  it "rejects unsupported commands" do
-    expect_raises(Butler::UnknownInstruction) do
-      Butler::Dispatcher.dispatch!(["igbanam"])
+module Butler
+  describe Dispatcher do
+    it "rejects unsupported instructions" do
+      expect_raises(UnknownInstruction) do
+        Dispatcher.dispatch!(["igbanam"])
+      end
+    end
+
+    it "routes 'task add' to the AddTask instruction" do
+      intent = "task add Begin!".split
+      instruction = Dispatcher.new(intent.first, intent[1..-1]).route
+      instruction.is_a?(Instruction::CreateTask).should be_true
     end
   end
 end

--- a/spec/butler/instructions_spec.cr
+++ b/spec/butler/instructions_spec.cr
@@ -35,10 +35,10 @@ module Butler
           expected.should_not eq(fresh)
         end
       end
-    end
 
-    Spec.after_each do
-      FileUtils.rm_r(".butler") if File.directory?(".butler")
+      after_each do
+        FileUtils.rm_rf BUTLER_DIRECTORY
+      end
     end
   end
 end

--- a/spec/butler/store_spec.cr
+++ b/spec/butler/store_spec.cr
@@ -1,0 +1,46 @@
+require "../spec_helper"
+
+module Butler
+  describe Store do
+    it "must be singleton" do
+      a = Store.instance
+      b = Store.instance
+
+      a.should be(b)
+    end
+
+    describe "#save" do
+      it "adds task to the task list" do
+        store_size = Store.instance.tasks.size
+
+        Store.instance.save Entity::Task.new(title: "test")
+        new_store_size = Store.instance.tasks.size
+
+        new_store_size.should eq(store_size + 1)
+      end
+
+      context "for duplicate tasks" do
+        it "leaves the store unchanged" do
+          Store.instance.save Entity::Task.new(title: "test")
+          store_size = Store.instance.tasks.size
+
+          Store.instance.save Entity::Task.new(title: "test")
+          new_store_size = Store.instance.tasks.size
+
+          new_store_size.should eq(store_size)
+        end
+      end
+    end
+
+    describe "#unique?" do
+      it "is false for an exact match on title" do
+        task = Entity::Task.new(title: "test")
+        Store.instance.save task
+
+        uniqueness = Store.instance.unique? task
+
+        uniqueness.should be_false
+      end
+    end
+  end
+end

--- a/spec/butler/store_spec.cr
+++ b/spec/butler/store_spec.cr
@@ -1,7 +1,13 @@
+require "file_utils"
 require "../spec_helper"
 
 module Butler
   describe Store do
+    before_all do
+      FileUtils.rm_rf BUTLER_DIRECTORY
+      Instruction::Initialize.new([] of String).execute
+    end
+
     it "must be singleton" do
       a = Store.instance
       b = Store.instance
@@ -41,6 +47,10 @@ module Butler
 
         uniqueness.should be_false
       end
+    end
+
+    after_all do
+      FileUtils.rm_rf BUTLER_DIRECTORY
     end
   end
 end

--- a/src/butler/datatypes.cr
+++ b/src/butler/datatypes.cr
@@ -1,0 +1,21 @@
+require "json"
+
+module Butler
+  module Entity
+    class Task
+      include JSON::Serializable
+
+      @[JSON::Field(key: "title")]
+      property title : String
+
+      @[JSON::Field(key: "completed_at", emit_null: true)]
+      property completed_at : (Time)?
+
+      def initialize(@title)
+        @completed_at = nil
+      end
+
+      def initialize(@title, @completed_at); end
+    end
+  end
+end

--- a/src/butler/dispatcher.cr
+++ b/src/butler/dispatcher.cr
@@ -2,11 +2,12 @@ module Butler
   class Dispatcher
     SUPPORTED_INSTRUCTIONS = [
       "init",
-      "tasks"
+      "task"
     ]
 
     COMMAND_MAP = {
       "init" => Butler::Instruction::Initialize,
+      "task-add" => Butler::Instruction::CreateTask
     }
 
     def self.dispatch!(intent : Array(String))
@@ -27,8 +28,16 @@ module Butler
     def initialize(@instruction : String, @details : Array(String))
     end
 
-    def dispatch : Nil
-      COMMAND_MAP[@instruction].new(@details).execute
+    def dispatch
+      route.execute
+    end
+
+    def route : Instruction::Instruction
+      if @instruction == "task" # this is an umbrella instruction
+        @instruction = "#{@instruction}-#{@details[0]}"
+        @details = @details[1..-1]
+      end
+      COMMAND_MAP[@instruction].new(@details)
     end
   end
 

--- a/src/butler/errors.cr
+++ b/src/butler/errors.cr
@@ -1,3 +1,0 @@
-module Butler
-  class UnknownInstruction < Exception; end
-end

--- a/src/butler/exceptions.cr
+++ b/src/butler/exceptions.cr
@@ -1,4 +1,5 @@
 module Butler
+  class ConfusedButler < Exception; end
   class MalformedInstruction < Exception; end
   class UnknownInstruction < Exception; end
 end

--- a/src/butler/instructions.cr
+++ b/src/butler/instructions.cr
@@ -1,5 +1,6 @@
 module Butler
   BUTLER_DIRECTORY = ".butler"
+  BUTLER_DATA = "#{BUTLER_DIRECTORY}/store.json"
   # .butler
   #   +-> service.log
   #   +-> tasks.json
@@ -7,6 +8,7 @@ module Butler
   module Instruction
     abstract class Instruction
       abstract def execute
+      abstract def to_s
 
       def reject!(concern)
         raise concern
@@ -21,13 +23,44 @@ module Butler
 
       def execute
         create_butler_directory
+        initialize_store
         Butler::Logger.instance.log "Initialized Butler in #{__DIR__}"
       rescue File::AlreadyExistsError
+        Butler::Logger.instance.log "Reinitialized Butler in #{__DIR__}"
         STDERR.puts "Your butler is already initialized."
+      end
+
+      def to_s
+        "butler init"
       end
 
       private def create_butler_directory
         Dir.mkdir BUTLER_DIRECTORY
+      end
+
+      private def initialize_store
+        Store.instance
+      end
+    end
+
+    class CreateTask < Instruction
+      @details : String
+
+      def initialize(details : Array(String))
+        error_message = "Tasks syntax is  ---> ./butler tasks add [TITLE]"
+        reject!(concern: MalformedInstruction.new(error_message)) if details.empty?
+        @details = details.join
+        Butler::Logger.instance.log self
+      end
+
+      def execute
+        task = Entity::Task.new(title: @details)
+        Store.instance.save task
+        Store.instance.persist!
+      end
+
+      def to_s
+        "butler task create #{@details}"
       end
     end
   end

--- a/src/butler/logger.cr
+++ b/src/butler/logger.cr
@@ -8,9 +8,21 @@ module Butler
       @@instance ||= new
     end
 
-    def log(message : String) : Nil
-      File.open(@logfile_path, "a") do |log_file|
-        log_file.puts message
+    def log(message : String)
+      write message
+    end
+
+    def log(instruction : Instruction::Instruction)
+      write "[event] #{instruction}"
+    end
+
+    private def write(content : String)
+      content += "\n"
+
+      if File.exists? @logfile_path
+        File.write @logfile_path, content, mode: "a"
+      else
+        File.write @logfile_path, content
       end
     end
   end

--- a/src/butler/store.cr
+++ b/src/butler/store.cr
@@ -10,7 +10,6 @@ module Butler
     end
 
     def persist!
-      puts "Tasks are #{@tasks}"
       File.write @store_path, @tasks.to_json
     end
 

--- a/src/butler/store.cr
+++ b/src/butler/store.cr
@@ -1,0 +1,44 @@
+require "json"
+require "./datatypes"
+
+module Butler
+  class Store
+    @tasks = [] of Entity::Task
+
+    def self.instance
+      @@instance ||= new
+    end
+
+    def persist!
+      puts "Tasks are #{@tasks}"
+      File.write @store_path, @tasks.to_json
+    end
+
+    def save(task : Entity::Task)
+      @tasks << task if unique?(task)
+    end
+
+    def unique?(task : Entity::Task)
+      !@tasks.map { |task| task.title }.includes?(task.title)
+    end
+
+    protected def tasks
+      @tasks
+    end
+
+    private def initialize
+      @store_path = BUTLER_DATA
+      File.exists?(BUTLER_DATA) ? load : create
+    end
+
+    private def create
+      raise ConfusedButler.new unless @tasks.empty?
+      persist!
+    end
+
+    private def load
+      tasks_json = File.read @store_path
+      @tasks = Array(Entity::Task).from_json(tasks_json)
+    end
+  end
+end


### PR DESCRIPTION
Here we add some tasks to the Butler. Man's gotta know what to keep
track of. This is a simple "create a card on Trello"; so nothing fancy.
But there are some design decisions I am slowly realizing needs to be
made.

- Storage: currently, this is in a flat file as JSON, but it could be
something more elaborate as time goes on and the entity space grows.
- TDD: TBH, IDGAF. I'd rather build this out first... then create a test
harness later. That's just how my brain works. — although, I had to
write tests for the Store at some point cos mans didn't understand what
Crystal was doing behind the scenes. Turns out all the test you see for
the Store module was to prefix the expression in `Store#unique?` with !
- Sugar: `task add` is a backward way of speaking. I realize this is how
programmers speak, but Butlers are more polished. I would have to
introduce some sugar to this. What I currently don't know is how this
plays with the help text.
- Exceptions: I was just an ass here. I don't know why I tried to
maintain "errors" and "exceptions"

Writing to the datastore is an atomic task. This is could become a
problem if the number of tasks become ginormous cos I'm handling this in
one process. But when we get to that bridge, we'd cross it. i cannot
come and go and kill myself. Here's the note that I am aware of it.

At this point, I can add tasks. But there's nothing I can do with this
ability because Butler neither knows how to show me these tasks, nor how
to interact with them.