### PR TITLE
Deprecate TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: crystal
-
-# Uncomment the following if you'd like Travis to run specs and check code formatting
-# script:
-  - crystal spec
-  - crystal tool format --check


### PR DESCRIPTION
Since I am using Github Workflows for this, there's no need keeping this
around.

I never figured out how to work the damn thing anyways.